### PR TITLE
Додано оновлення доменів порціями по 500

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ## Автоматизація
 - `python scripts/check_lists.py` — перевіряє списки, виявляє дублікати й помилки.
 - `python scripts/generate_lists.py` — створює формати для AdGuard та uBlock у каталозі `dist/`.
-- `python scripts/update_domains.py` — завантажує домени зі сторонніх перевірених списків і додає їх у `domains.txt`.
+- `python scripts/update_domains.py` — завантажує домени зі сторонніх перевірених списків і додає їх у `domains.txt` порціями по 500.
 
 ## Джерела доменів
 Скрипт `update_domains.py` використовує публічні списки, що регулярно оновлюються:

--- a/scripts/update_domains.py
+++ b/scripts/update_domains.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 from urllib.request import urlopen
 
+CHUNK_SIZE = 500
+
 DOMAINS_FILE = Path("domains.txt")
 SOURCES = [
     "https://urlhaus.abuse.ch/downloads/hostfile/",
@@ -39,7 +41,7 @@ def _fetch(url: str) -> list[str]:
     return domains
 
 
-def update() -> None:
+def update(chunk_size: int = CHUNK_SIZE) -> None:
     existing = set()
     if DOMAINS_FILE.exists():
         existing = {
@@ -52,7 +54,11 @@ def update() -> None:
     for url in SOURCES:
         fetched.update(_fetch(url))
 
-    merged = sorted(existing | fetched)
+    new_domains = sorted(fetched - existing)[:chunk_size]
+    if not new_domains:
+        return
+
+    merged = sorted(existing | set(new_domains))
     DOMAINS_FILE.write_text("\n".join(merged) + "\n")
 
 


### PR DESCRIPTION
## Опис
- додано посторінкове поповнення списку доменів (до 500 за запуск)
- оновлено README з описом нової поведінки

## Тестування
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_6892e163a2b4832e8f8bfffd14bc8e1b