### PR TITLE
Розширено список доменів: gosuslugi.ru, sberbank.ru, kremlin.ru та ін.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 - Налаштовано CI з GitHub Actions та pre-commit.
 - Додано ліцензію та зміни до документації.
 - Додано джерела рекламних, фішингових та азартних доменів.
+- Додано домени gosuslugi.ru, sberbank.ru, kremlin.ru, mos.ru, tass.ru, ria.ru, rbc.ru, lenta.ru, gazprombank.ru та vtb.ru.

--- a/README.md
+++ b/README.md
@@ -66,5 +66,15 @@
 - `static.okko.tv`
 - `tse2.explicit.bing.net`
 - `zakpos.mine.nu`
+- `gosuslugi.ru`
+- `sberbank.ru`
+- `kremlin.ru`
+- `mos.ru`
+- `tass.ru`
+- `ria.ru`
+- `rbc.ru`
+- `lenta.ru`
+- `gazprombank.ru`
+- `vtb.ru`
 
 Перелік буде поповнюватися.

--- a/domains.txt
+++ b/domains.txt
@@ -24,6 +24,16 @@ shiro.senkuro.org
 static.okko.tv
 tse2.explicit.bing.net
 zakpos.mine.nu
+gosuslugi.ru
+sberbank.ru
+kremlin.ru
+mos.ru
+tass.ru
+ria.ru
+rbc.ru
+lenta.ru
+gazprombank.ru
+vtb.ru
 0-1-x.06215785.xyz
 0-1-x.15170956.xyz
 0-1-x.16215785.xyz


### PR DESCRIPTION
## Опис
- додано домени gosuslugi.ru, sberbank.ru, kremlin.ru, mos.ru, tass.ru, ria.ru, rbc.ru, lenta.ru, gazprombank.ru та vtb.ru до `domains.txt`
- оновлено `README.md` та `CHANGELOG.md`

## Тестування
- `python scripts/check_lists.py`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_6892e4eb6b70832eb12cc7bda48bc0db