### PR TITLE
Додати тести для CLI та спростити генерацію списків

### DIFF
--- a/scripts/generate_lists.py
+++ b/scripts/generate_lists.py
@@ -33,8 +33,7 @@ def generate(
         (dist_dir / "adguard.txt").write_text("\n".join(base) + "\n")
 
     if "ublock" in formats:
-        ublock = list(base)
-        (dist_dir / "ublock.txt").write_text("\n".join(ublock) + "\n")
+        (dist_dir / "ublock.txt").write_text("\n".join(base) + "\n")
 
     if "hosts" in formats:
         hosts = [f"0.0.0.0 {d}" for d in domains]

--- a/tests/test_check_lists.py
+++ b/tests/test_check_lists.py
@@ -1,8 +1,10 @@
+import scripts.check_lists as check_lists
 from scripts.check_lists import (
     _find_cross_duplicates,
     _find_duplicates,
     _validate_domains,
     _validate_regexes,
+    main,
 )
 
 
@@ -24,3 +26,27 @@ def test_validate_domains():
 
 def test_validate_regexes():
     assert _validate_regexes([r"^good$", r"["]) == ["["]
+
+
+def test_main(tmp_path, monkeypatch, capsys):
+    domains = tmp_path / "domains.txt"
+    regex = tmp_path / "regex.list"
+    domains.write_text("example.com\n")
+    regex.write_text(r"good.*\n")
+    monkeypatch.setattr(check_lists, "DOMAINS_FILE", domains)
+    monkeypatch.setattr(check_lists, "REGEX_FILE", regex)
+    assert main() == 0
+    assert capsys.readouterr().out.strip() == "Списки коректні"
+
+
+def test_main_invalid(tmp_path, monkeypatch, capsys):
+    domains = tmp_path / "domains.txt"
+    regex = tmp_path / "regex.list"
+    domains.write_text("bad_domain\n")
+    regex.write_text("[\n")
+    monkeypatch.setattr(check_lists, "DOMAINS_FILE", domains)
+    monkeypatch.setattr(check_lists, "REGEX_FILE", regex)
+    assert main() == 1
+    out = capsys.readouterr().out
+    assert "Некоректні домени" in out
+    assert "Некоректні регулярні вирази" in out

--- a/tests/test_update_domains.py
+++ b/tests/test_update_domains.py
@@ -53,3 +53,17 @@ def test_update_parallel_fetch(tmp_path, monkeypatch):
     dest = tmp_path / "domains.txt"
     update_domains.update(dest=dest, sources=["u1", "u2"])
     assert set(calls) == {"u1", "u2"}
+
+
+def test_main_passes_args(tmp_path, monkeypatch):
+    called: dict[str, object] = {}
+
+    def fake_update(*, dest, chunk_size, sources=update_domains.SOURCES):
+        called["dest"] = dest
+        called["chunk_size"] = chunk_size
+
+    monkeypatch.setattr(update_domains, "update", fake_update)
+    dest = tmp_path / "out.txt"
+    update_domains.main(["--chunk-size", "7", "--dest", str(dest)])
+    assert called["dest"] == dest
+    assert called["chunk_size"] == 7


### PR DESCRIPTION
## Опис
- спрощено генерацію uBlock без зайвого копіювання
- додано тести для `check_lists.main` та `update_domains.main`

## Тестування
- `pre-commit run --files scripts/generate_lists.py tests/test_check_lists.py tests/test_update_domains.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aed695e028832ea755151d2579530b