### PR TITLE
Додано нові російські пропагандистські домени

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@
 - `yandex.ru`
 - `ok.ru`
 - `rt.com`
+- `1tv.ru`
+- `smotrim.ru`
 - `sputniknews.com`
 - `a.tiktokmod.pro`
 - `hideservers.net`
@@ -99,6 +101,7 @@
 - `rbc.ru`
 - `lenta.ru`
 - `gazprombank.ru`
+- `vgtrk.ru`
 - `vtb.ru`
 
 Перелік буде поповнюватися.

--- a/data/catalog.json
+++ b/data/catalog.json
@@ -50,6 +50,42 @@
       "notes": "Міжнародний канал російської пропаганди."
     },
     {
+      "value": "1tv.ru",
+      "category": "пропаганда",
+      "regions": ["ru", "global"],
+      "sources": ["ручне внесення"],
+      "added": "2025-09-28",
+      "severity": "висока",
+      "status": "active",
+      "monitor": true,
+      "tags": ["телеканал", "змі"],
+      "notes": "Перший канал РФ, один з головних державних пропагандистських ресурсів."
+    },
+    {
+      "value": "smotrim.ru",
+      "category": "пропаганда",
+      "regions": ["ru", "global"],
+      "sources": ["ручне внесення"],
+      "added": "2025-09-28",
+      "severity": "висока",
+      "status": "active",
+      "monitor": true,
+      "tags": ["стрімінг", "змі"],
+      "notes": "Стрімінгова платформа ВГТРК з трансляціями державних телеканалів."
+    },
+    {
+      "value": "vgtrk.ru",
+      "category": "пропаганда",
+      "regions": ["ru", "cis"],
+      "sources": ["ручне внесення"],
+      "added": "2025-09-28",
+      "severity": "висока",
+      "status": "active",
+      "monitor": true,
+      "tags": ["медіахолдинг"],
+      "notes": "Державний медіахолдинг РФ, що керує телеканалами та радіо ВГТРК."
+    },
+    {
       "value": "phishing-army.net",
       "category": "фішинг",
       "regions": ["global"],

--- a/domains.txt
+++ b/domains.txt
@@ -20594,6 +20594,7 @@ beardpool.rocks
 beastminingpool.com
 checkip.deepstateplatypus.com
 creative.hpyrdr.com
+1tv.ru
 dev.period-calendar.com
 fcm-pc.period-calendar.com
 fetside.com
@@ -20620,6 +20621,7 @@ primaryns.kiev.ua
 rbc.ru
 ria.ru
 rt.com
+smotrim.ru
 sberbank.ru
 shiro.senkuro.org
 sputniknews.com
@@ -20632,5 +20634,6 @@ torproject.org
 tse2.explicit.bing.net
 vk.com
 vtb.ru
+vgtrk.ru
 yandex.ru
 zakpos.mine.nu


### PR DESCRIPTION
## Summary
- додано 1tv.ru, smotrim.ru та vgtrk.ru до основного списку доменів
- доповнено каталог метаданими для нових записів
- оновлено README з актуальним переліком доменів

## Testing
- python scripts/check_lists.py *(очікуваний вихід 1 через наявні у вихідному списку некоректні записи, що були й до змін)*

------
https://chatgpt.com/codex/tasks/task_e_68d97117cee4832ebf365ec1169f95ba