### PR TITLE
Додано домени life.ru та rutube.ru

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@
 - `ria.ru`
 - `rbc.ru`
 - `lenta.ru`
+- `life.ru`
 - `gazprombank.ru`
+- `rutube.ru`
 - `vgtrk.ru`
 - `vtb.ru`
 

--- a/data/catalog.json
+++ b/data/catalog.json
@@ -86,6 +86,30 @@
       "notes": "Державний медіахолдинг РФ, що керує телеканалами та радіо ВГТРК."
     },
     {
+      "value": "life.ru",
+      "category": "пропаганда",
+      "regions": ["ru", "global"],
+      "sources": ["ручне внесення"],
+      "added": "2025-09-28",
+      "severity": "висока",
+      "status": "active",
+      "monitor": true,
+      "tags": ["змі"],
+      "notes": "Пропагандистський медіахолдинг Life, що поширює кремлівські наративи."
+    },
+    {
+      "value": "rutube.ru",
+      "category": "пропаганда",
+      "regions": ["ru", "global"],
+      "sources": ["ручне внесення"],
+      "added": "2025-09-28",
+      "severity": "висока",
+      "status": "active",
+      "monitor": true,
+      "tags": ["відеоплатформа", "змі"],
+      "notes": "Відеоплатформа Rutube, що належить державним структурам РФ і використовується для пропаганди."
+    },
+    {
       "value": "phishing-army.net",
       "category": "фішинг",
       "regions": ["global"],

--- a/domains.txt
+++ b/domains.txt
@@ -20608,6 +20608,7 @@ ipinfo.suinfra.com
 kms.03k.org
 kremlin.ru
 lenta.ru
+life.ru
 mail.ru
 mailgate.cryptonight.net
 mandrillapp.com
@@ -20621,6 +20622,7 @@ primaryns.kiev.ua
 rbc.ru
 ria.ru
 rt.com
+rutube.ru
 smotrim.ru
 sberbank.ru
 shiro.senkuro.org


### PR DESCRIPTION
## Summary
- додано домени life.ru та rutube.ru до основного списку блокувань
- описано нові домени у каталозі метаданих із позначками категорій і тегів
- оновлено README з переліком поточних доменів

## Testing
- not run (оновлено лише дані)


------
https://chatgpt.com/codex/tasks/task_e_68d986f32fe8832e865e0aafeffc7227