### PR TITLE
Відновити автодоповнення модулів пакета scripts

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,32 @@
+"""Загальний простір імен для CLI-скриптів із ледачим імпортом."""
+from __future__ import annotations
+
+from importlib import import_module
+from types import ModuleType
+from typing import TYPE_CHECKING
+
+__all__ = [
+    "check_lists",
+    "generate_lists",
+    "update_domains",
+    "utils",
+]
+
+if TYPE_CHECKING:  # pragma: no cover
+    from . import check_lists, generate_lists, update_domains, utils  # noqa: F401
+
+
+def _load_module(name: str) -> ModuleType:
+    module = import_module(f".{name}", __name__)
+    globals()[name] = module
+    return module
+
+
+def __getattr__(name: str) -> ModuleType:
+    if name in __all__:
+        return _load_module(name)
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
+
+def __dir__() -> list[str]:  # pragma: no cover - використовується інтерактивно
+    return sorted(set(globals()) | set(__all__))

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,0 +1,10 @@
+import importlib
+
+
+def test_scripts_package_exposes_modules():
+    scripts = importlib.import_module("scripts")
+    available = dir(scripts)
+    for name in ["check_lists", "generate_lists", "update_domains", "utils"]:
+        assert name in available
+        module = getattr(scripts, name)
+        assert module.__name__.endswith(name)


### PR DESCRIPTION
## Summary
- додано ледачий імпорт у `scripts/__init__.py`, щоб модулі були видимими для автодоповнення
- додано модульний тест, що перевіряє наявність основних скриптів у `dir(scripts)`

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d98e512e3c832e8382a0d9d56a1248