### PR TITLE
Додано пропагандистські домени tsargrad.tv, eadaily.com та vz.ru

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@
 - `api.mainnet.minepi.com`
 - `checkip.deepstateplatypus.com`
 - `dev.period-calendar.com`
+- `eadaily.com`
 - `fcm-pc.period-calendar.com`
 - `fetside.com`
 - `free-de-ds.hideservers.net`
@@ -116,11 +117,13 @@
 - `sputniknews.com`
 - `static.okko.tv`
 - `tass.ru`
+- `tsargrad.tv`
 - `tvzvezda.ru`
 - `tse2.explicit.bing.net`
 - `vgtrk.ru`
 - `vk.com`
 - `vtb.ru`
+- `vz.ru`
 - `yandex.ru`
 - `zakpos.mine.nu`
 

--- a/docs/key-domains/propaganda-media.md
+++ b/docs/key-domains/propaganda-media.md
@@ -1,6 +1,7 @@
 # Пропагандистські та медійні ресурси
 
 - `1tv.ru`
+- `eadaily.com`
 - `life.ru`
 - `lenta.ru`
 - `rbc.ru`
@@ -12,5 +13,7 @@
 - `sputnikglobe.com`
 - `sputniknews.com`
 - `tass.ru`
+- `tsargrad.tv`
 - `tvzvezda.ru`
 - `vgtrk.ru`
+- `vz.ru`

--- a/domains.txt
+++ b/domains.txt
@@ -20596,6 +20596,7 @@ checkip.deepstateplatypus.com
 creative.hpyrdr.com
 1tv.ru
 dev.period-calendar.com
+eadaily.com
 fcm-pc.period-calendar.com
 fetside.com
 forum.cryptonight.net
@@ -20640,11 +20641,13 @@ tass.ru
 torproject.com
 torproject.net
 torproject.org
+tsargrad.tv
 tse2.explicit.bing.net
 tvzvezda.ru
 vesti.ru
 vk.com
 vtb.ru
 vgtrk.ru
+vz.ru
 yandex.ru
 zakpos.mine.nu


### PR DESCRIPTION
## Summary
- додано домени eadaily.com, tsargrad.tv та vz.ru до основного списку блокування
- оновлено довідник ключових пропагандистських ресурсів і README для відображення нових записів

## Testing
- not run (оновлення списків)

------
https://chatgpt.com/codex/tasks/task_e_68e37221eb9c832e9c9086bbe46ef172