### PR TITLE
Розширити можливості фільтрації каталогу

### DIFF
--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -39,6 +39,8 @@ class EntryMetadata:
         regions: Sequence[str] | None = None,
         sources: Sequence[str] | None = None,
         statuses: Sequence[str] | None = None,
+        severities: Sequence[str] | None = None,
+        tags: Sequence[str] | None = None,
     ) -> bool:
         """Перевіряє, чи відповідає запис заданим фільтрам."""
 
@@ -46,9 +48,14 @@ class EntryMetadata:
             return False
         if statuses and self.status not in statuses:
             return False
+        if severities:
+            if not self.severity or self.severity not in severities:
+                return False
         if regions and not set(self.regions) & set(regions):
             return False
         if sources and not set(self.sources) & set(sources):
+            return False
+        if tags and not set(self.tags) & set(tags):
             return False
         return True
 
@@ -76,6 +83,8 @@ class Catalog:
         regions: Sequence[str] | None = None,
         sources: Sequence[str] | None = None,
         statuses: Sequence[str] | None = None,
+        severities: Sequence[str] | None = None,
+        tags: Sequence[str] | None = None,
         include_missing: bool = True,
     ) -> Iterator[tuple[str, EntryMetadata | None]]:
         """Ітерує передані значення з урахуванням фільтрів."""
@@ -88,10 +97,18 @@ class Catalog:
                     regions=regions,
                     sources=sources,
                     statuses=statuses,
+                    severities=severities,
+                    tags=tags,
                 ):
                     yield value, metadata
-            elif include_missing and not categories and not regions and not sources and (
-                not statuses or "active" in statuses
+            elif (
+                include_missing
+                and not categories
+                and not regions
+                and not sources
+                and not severities
+                and not tags
+                and (not statuses or "active" in statuses)
             ):
                 yield value, None
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -48,3 +48,47 @@ def test_load_false_positive_lists(tmp_path):
     domains, regexes = load_false_positive_lists(data_file)
     assert domains == {"example.com"}
     assert regexes == {"bad"}
+
+
+def test_iter_values_filters_severity_and_tags(tmp_path):
+    catalog_file = tmp_path / "catalog.json"
+    catalog_file.write_text(
+        json.dumps(
+            {
+                "domains": [
+                    {
+                        "value": "phish.example",
+                        "category": "фішинг",
+                        "regions": ["global"],
+                        "sources": ["тест"],
+                        "status": "active",
+                        "severity": "високий",
+                        "tags": ["цільовий", "фішинг"],
+                    },
+                    {
+                        "value": "benign.example",
+                        "category": "інше",
+                        "regions": ["global"],
+                        "sources": ["тест"],
+                        "status": "active",
+                        "severity": "низький",
+                        "tags": ["whitelist"],
+                    },
+                ],
+                "regexes": [],
+            },
+            ensure_ascii=False,
+        )
+    )
+
+    catalog = load_catalog(catalog_file)
+    values = list(
+        catalog.iter_values_from(
+            ["phish.example", "benign.example", "unknown.example"],
+            kind="domain",
+            severities=["високий"],
+            tags=["фішинг"],
+        )
+    )
+
+    assert values == [("phish.example", catalog.metadata_for("phish.example", "domain"))]


### PR DESCRIPTION
## Підсумок
- додано підтримку фільтрації записів каталогу за критичністю та тегами
- розширено логіку пропуску відсутніх метаданих, якщо активні додаткові фільтри
- створено юніт-тест для перевірки нових фільтрів

## Тестування
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e425921aac832ea3a1e097b117fe0e