### PR TITLE
Fix CI and local quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,30 +7,33 @@ on:
   schedule:
     - cron: '0 6 * * 1'
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: 'pip'
       - name: Встановлення залежностей
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-      - name: Встановлення інструментів безпеки
-        run: pip install pip-audit bandit
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install -r requirements.txt
       - name: Аналіз залежностей (pip-audit)
-        run: pip-audit --strict
+        run: python -m pip_audit --strict
       - name: Статичний аналіз безпеки (bandit)
-        run: bandit -r scripts -ll
+        run: python -m bandit -r scripts -ll
       - name: Перевірка списків
         run: python scripts/check_lists.py
       - name: Запуск тестів із покриттям
-        run: coverage run -m pytest -q
+        run: python -m coverage run -m pytest -q
       - name: Перевірка порогу покриття
-        run: coverage report --fail-under=85
+        run: python -m coverage report --fail-under=85
       - name: Перевірка генерації списків
         run: python scripts/generate_lists.py --dist-dir dist --formats adguard ublock hosts
       - name: Формування контрольних сум
@@ -39,7 +42,7 @@ jobs:
           find . -type f -print0 | sort -z | xargs -0 sha256sum > checksums.txt
           test -s checksums.txt
       - name: Завантаження артефактів списків
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: generated-lists
           path: dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,14 @@
 [tool.ruff]
 line-length = 100
 target-version = "py311"
+exclude = [
+  ".git",
+  ".venv",
+  "dist",
+  "reports",
+]
+
+[tool.ruff.lint]
 select = [
   "E",  # pycodestyle
   "F",  # pyflakes
@@ -10,12 +18,6 @@ select = [
 ignore = [
   "E203",  # whitespace before ':' (black compat)
   "E501",  # line length handled by formatter/checks elsewhere
-]
-exclude = [
-  ".git",
-  ".venv",
-  "dist",
-  "reports",
 ]
 
 [tool.ruff.format]
@@ -42,5 +44,3 @@ fail_under = 85
 [tool.bandit]
 skips = ["B101"]  # allow assert in tests
 targets = ["scripts"]
-
-

--- a/tasks.ps1
+++ b/tasks.ps1
@@ -9,32 +9,14 @@ $ErrorActionPreference = "Stop"
 function Run-Tests { pytest -q }
 function Run-Lint {
   ruff check .
-  $savedPreference = $ErrorActionPreference
-  $ErrorActionPreference = "Continue"
-  try {
-    bandit -r scripts -ll | Out-Host
-    # Ignore exit code (matches bash "|| true" behavior)
-  } catch {
-    # Continue execution even if bandit fails
-  } finally {
-    $ErrorActionPreference = $savedPreference
-  }
+  bandit -r scripts -ll
 }
 function Run-Format {
   ruff format .
   black .
 }
 function Run-Audit {
-  $savedPreference = $ErrorActionPreference
-  $ErrorActionPreference = "Continue"
-  try {
-    pip-audit --strict | Out-Host
-    # Ignore exit code (matches bash "|| true" behavior)
-  } catch {
-    # Continue execution even if pip-audit fails
-  } finally {
-    $ErrorActionPreference = $savedPreference
-  }
+  pip-audit --strict
 }
 function Run-Generate { python scripts/generate_lists.py --formats adguard ublock hosts }
 
@@ -47,8 +29,6 @@ switch ($Cmd) {
   "gen" { Run-Generate }
   "generate" { Run-Generate }
   Default {
-    Write-Host "Usage: .\\tasks.ps1 [test|lint|format|audit|generate]"
+    Write-Host "Usage: .\tasks.ps1 [test|lint|format|audit|generate]"
   }
 }
-
-

--- a/tasks.sh
+++ b/tasks.sh
@@ -9,7 +9,7 @@ run_tests() {
 
 run_lint() {
   ruff check .
-  bandit -r scripts -ll || true
+  bandit -r scripts -ll
 }
 
 run_format() {
@@ -18,7 +18,7 @@ run_format() {
 }
 
 run_audit() {
-  pip-audit --strict || true
+  pip-audit --strict
 }
 
 run_generate() {
@@ -35,5 +35,3 @@ case "$cmd" in
     echo "Usage: $0 [test|lint|format|audit|generate]";
     ;;
 esac
-
-


### PR DESCRIPTION
## Що змінено

- Оновлено GitHub Actions у CI до підтримуваних major-версій: `actions/checkout@v4`, `actions/setup-python@v5`, `actions/upload-artifact@v4`.
- Додано `permissions: contents: read`, `timeout-minutes` для job та pip cache у CI.
- Переведено запуск `pip-audit`, `bandit`, `coverage` на `python -m ...`, щоб зменшити ризик проблем із PATH.
- `tasks.sh` і `tasks.ps1` більше не приховують падіння `bandit` та `pip-audit`: локальні quality gates тепер поводяться узгоджено з CI.
- Перенесено Ruff lint-конфіг із deprecated top-level секції `[tool.ruff]` у `[tool.ruff.lint]`.

## Ризики

- Якщо у залежностях або коді вже є реальні security findings, локальні `tasks.sh lint/audit` та `tasks.ps1 lint/audit` тепер падатимуть — це бажана поведінка для quality gate.

## Перевірка

- Перевірено diff між `main` і `fix/ci-and-quality-gates`: змінено 4 файли — `.github/workflows/ci.yml`, `pyproject.toml`, `tasks.sh`, `tasks.ps1`.
- Повний CI має пройти після запуску GitHub Actions на Pull Request.